### PR TITLE
Add missing repo name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Homebrew formula for our homebrewed software.
 
 First, tap it:
 
-`$ brew tap leancodepl`
+`$ brew tap leancodepl/tools`
 
 Then, you can install some programs, e.g
 [mobile-tools](https://github.com/leancodepl/mobile-tools):


### PR DESCRIPTION
~~I guess this should be changed as well?:~~

~~https://github.com/leancodepl/mobile-tools/blob/048d7a1cfb790b0105af6d0cc660e52b03577a6a/README.md?plain=1#L7~~